### PR TITLE
feat: site title is now Link to navigate to home

### DIFF
--- a/packages/gatsby-theme-kb/src/components/SiteSidebar/index.tsx
+++ b/packages/gatsby-theme-kb/src/components/SiteSidebar/index.tsx
@@ -68,9 +68,10 @@ export default function SiteSidebar(props: ISiteSidebarProps) {
     }
   `)
 
-
   const [treeNodes, setTreeNodes] = useState<TreeNodeRawData[]>([])
-  const [treeDataMap, setTreeDataMap] = useState<Record<string, TreeNodeRawData>>({})
+  const [treeDataMap, setTreeDataMap] = useState<
+    Record<string, TreeNodeRawData>
+  >({})
   const [nodeMap, setNodeMap] = useState<Record<string, RemarkNode>>({})
 
   // initialize
@@ -145,12 +146,15 @@ export default function SiteSidebar(props: ISiteSidebarProps) {
     return () => {}
   }, [])
 
-  const onNodeSelect = useCallback((treeNode) => {
-    const node = nodeMap[treeNode.id]
-    if (node) {
-      navigate(node.parent.fields.slug)
-    }
-  }, [nodeMap])
+  const onNodeSelect = useCallback(
+    (treeNode) => {
+      const node = nodeMap[treeNode.id]
+      if (node) {
+        navigate(node.parent.fields.slug)
+      }
+    },
+    [nodeMap]
+  )
 
   const renderLabel: TreeNodeProps['renderLabel'] = useCallback(
     (nodeProps, { labelClassName }) => {
@@ -206,7 +210,9 @@ export default function SiteSidebar(props: ISiteSidebarProps) {
 
   return (
     <div className="site-sidebar py-5 px-2">
-      <div className="site-sidebar__title">{title}</div>
+      <div className="site-sidebar__title">
+        <Link to="/">{title}</Link>
+      </div>
       <div className="site-sidebar__search">
         <Search
           isMobileMode={isMobileMode}

--- a/packages/gatsby-theme-kb/src/components/SiteSidebar/site-sidebar.css
+++ b/packages/gatsby-theme-kb/src/components/SiteSidebar/site-sidebar.css
@@ -10,6 +10,14 @@
   font-size: large;
 }
 
+.site-sidebar__title a {
+  color: var(--kb-text-color);
+}
+
+.site-sidebar__title a:hover {
+  color: var(--kb-link-color);
+}
+
 .site-sidebar__link {
   color: var(--kb-text-color);
   display: block;


### PR DESCRIPTION
There was no way to navigate back to home after visiting other pages, so the site title is now a link that takes the user back to the home page.