### PR TITLE
fix: dark mode for graph view

### DIFF
--- a/packages/gatsby-theme-kb/src/components/GraphView/graph-view.css
+++ b/packages/gatsby-theme-kb/src/components/GraphView/graph-view.css
@@ -53,6 +53,10 @@
   font-size: 1.5em;
 }
 
+.force-graph-container canvas {
+  background-color: var(--bg-color-1) !important;
+}
+
 .modal-close,
 .modal-scale {
   position: absolute;

--- a/packages/gatsby-theme-kb/src/components/mdx-components/anchor-tag.css
+++ b/packages/gatsby-theme-kb/src/components/mdx-components/anchor-tag.css
@@ -5,7 +5,7 @@
   padding: 1rem;
   border-radius: 0.5rem;
   background-color: var(--kb-references-bg);
-  max-height: 20rem;
+  max-height: 26rem;
   overflow: overlay;
 }
 

--- a/packages/gatsby-theme-kb/src/components/mdx-components/anchor-tag.css
+++ b/packages/gatsby-theme-kb/src/components/mdx-components/anchor-tag.css
@@ -5,7 +5,7 @@
   padding: 1rem;
   border-radius: 0.5rem;
   background-color: var(--kb-references-bg);
-  max-height: 26rem;
+  max-height: 20rem;
   overflow: overlay;
 }
 


### PR DESCRIPTION
Dark mode didn't extend for graph visualisation, I am not sure if it was intentional. Thanks.