### PR TITLE
Add 'unist' dependencies in package.json

### DIFF
--- a/packages/gatsby-remark-wiki-link/package.json
+++ b/packages/gatsby-remark-wiki-link/package.json
@@ -26,9 +26,11 @@
     "url": "https://github.com/hikerpig/gatsby-project-kb/issues"
   },
   "devDependencies": {
-    "typescript": "^4.1.3"
+    "typescript": "^4.1.3",
+    "@types/unist": "^2.0.6"
   },
   "dependencies": {
-    "slugify": "^1.4.6"
+    "slugify": "^1.4.6",
+    "unist-util-visit": "^2.0.3"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3246,7 +3246,7 @@
   resolved "https://registry.npmjs.org/@types/tmp/-/tmp-0.0.33.tgz#1073c4bc824754ae3d10cfab88ab0237ba964e4d"
   integrity sha1-EHPEvIJHVK49EM+riKsCN7qWTk0=
 
-"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3":
+"@types/unist@*", "@types/unist@^2.0.0", "@types/unist@^2.0.2", "@types/unist@^2.0.3", "@types/unist@^2.0.6":
   version "2.0.6"
   resolved "https://registry.npmjs.org/@types/unist/-/unist-2.0.6.tgz#250a7b16c3b91f672a24552ec64678eeb1d3a08d"
   integrity sha512-PBjIUxZHOuj0R15/xuwJYjFi+KZdNFrehocChv4g5hu6aFroHue8m0lBP0POdK2nKzbw0cgV1mws8+V/JAcEkQ==
@@ -16481,7 +16481,7 @@ unist-util-visit-parents@^3.0.0:
     "@types/unist" "^2.0.0"
     unist-util-is "^4.0.0"
 
-unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.2:
+unist-util-visit@2.0.3, unist-util-visit@^2.0.0, unist-util-visit@^2.0.2, unist-util-visit@^2.0.3:
   version "2.0.3"
   resolved "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-2.0.3.tgz#c3703893146df47203bb8a9795af47d7b971208c"
   integrity sha512-iJ4/RczbJMkD0712mGktuGpm/U4By4FfDonL7N/9tATGIF4imikjOuagyMY53tnZq3NP6BcmlrHhEKAfGWjh7Q==


### PR DESCRIPTION
Hi!, 
I've come across an issue with using the gatsby-remark-wiki-link package (standalone) in a yarn 2 project.
The `@types/unist` and `unist-util-visit` are used in the gatsby-remark-wiki-link package but not defined in the `package.json`. Yarn nags about this, so I thought let's fix it upstream.