### PR TITLE
Added sort by default to nodes

### DIFF
--- a/packages/gatsby-theme-kb/src/components/SiteSidebar/index.tsx
+++ b/packages/gatsby-theme-kb/src/components/SiteSidebar/index.tsx
@@ -77,7 +77,7 @@ export default function SiteSidebar(props: ISiteSidebarProps) {
   // initialize
   useEffect(() => {
     const nodes = data.allMdx!.nodes as RemarkNode[]
-    let validNodes = nodes.filter((node) => node.parent).sort((a,b) => {
+    const validNodes = nodes.filter((node) => node.parent).sort((a,b) => {
       if (a.parent.relativePath > b.parent.relativePath) return 1
       if (a.parent.relativePath < b.parent.relativePath) return -1
       return 0

--- a/packages/gatsby-theme-kb/src/components/SiteSidebar/index.tsx
+++ b/packages/gatsby-theme-kb/src/components/SiteSidebar/index.tsx
@@ -76,7 +76,12 @@ export default function SiteSidebar(props: ISiteSidebarProps) {
 
   // initialize
   useEffect(() => {
-    const nodes = data.allMdx!.nodes as RemarkNode[]
+    let nodes = data.allMdx!.nodes as RemarkNode[]
+    nodes = nodes.sort((a,b) => {
+      if (a.parent.relativePath > b.parent.relativePath) return 1
+      if (a.parent.relativePath < b.parent.relativePath) return -1
+      return 0
+    })
     const validNodes = nodes.filter((node) => node.parent)
 
     function makeDirectoryNodes(inputPath: string) {

--- a/packages/gatsby-theme-kb/src/components/SiteSidebar/index.tsx
+++ b/packages/gatsby-theme-kb/src/components/SiteSidebar/index.tsx
@@ -76,13 +76,12 @@ export default function SiteSidebar(props: ISiteSidebarProps) {
 
   // initialize
   useEffect(() => {
-    let nodes = data.allMdx!.nodes as RemarkNode[]
-    nodes = nodes.sort((a,b) => {
+    const nodes = data.allMdx!.nodes as RemarkNode[]
+    let validNodes = nodes.filter((node) => node.parent).sort((a,b) => {
       if (a.parent.relativePath > b.parent.relativePath) return 1
       if (a.parent.relativePath < b.parent.relativePath) return -1
       return 0
     })
-    const validNodes = nodes.filter((node) => node.parent)
 
     function makeDirectoryNodes(inputPath: string) {
       const directories = getDirectoriesByPath(inputPath)


### PR DESCRIPTION
By default the nodes are sorted by id, not by title or relativePath. This is a bit counter intuitive when you have a bunch of markdown files and folders with alphabetic sorting (e.g. "01 this is the first file" and "02 this is the second file") and they don't appear in the same sequence in the sidebar menu.

This little sort fixes that.
<img width="264" alt="image" src="https://user-images.githubusercontent.com/3264264/195987333-803bbe9a-08e6-4338-8c05-656f54c3d3aa.png">
